### PR TITLE
Fix a NullReferenceException for when the underlying value is null.

### DIFF
--- a/BluetoothLE.iOS/Characteristic.cs
+++ b/BluetoothLE.iOS/Characteristic.cs
@@ -109,7 +109,7 @@ namespace BluetoothLE.iOS
 		/// Gets the characteristic's value.
 		/// </summary>
 		/// <value>The characteristic's value.</value>
-		public byte[] Value { get { return _nativeCharacteristic.Value.ToArray(); } }
+		public byte[] Value { get { return _nativeCharacteristic.Value?.ToArray(); } }
 
 		/// <summary>
 		/// Gets the characteristic's value as a string.


### PR DESCRIPTION
This PR fixes an issue for the iOS integration whereby an underlying `null` value causes a `NullReferenceException` when retrieving the value (via either `Value` or `ValueString`).
